### PR TITLE
Add capitalization hinting to text fields

### DIFF
--- a/lib/screens/story/widgets/reply_box.dart
+++ b/lib/screens/story/widgets/reply_box.dart
@@ -189,6 +189,7 @@ class _ReplyBoxState extends State<ReplyBox> {
                                 border: InputBorder.none,
                               ),
                               keyboardType: TextInputType.multiline,
+                              textCapitalization: TextCapitalization.sentences,
                               textInputAction: TextInputAction.newline,
                               onChanged: widget.onChanged,
                             ),

--- a/lib/screens/submit/submit_screen.dart
+++ b/lib/screens/submit/submit_screen.dart
@@ -145,6 +145,7 @@ class _SubmitScreenState extends State<SubmitScreen> {
                     ),
                   ),
                   onChanged: context.read<SubmitCubit>().onTitleChanged,
+                  textCapitalization: TextCapitalization.word,
                 ),
               ),
               Padding(
@@ -187,6 +188,7 @@ class _SubmitScreenState extends State<SubmitScreen> {
                       ),
                     ),
                     onChanged: context.read<SubmitCubit>().onTextChanged,
+                    textCapitalization: TextCapitalization.sentences,
                   ),
                 ),
               ),


### PR DESCRIPTION
I was about to sub!it a feature request for this when I realized it's probably fairly simple.

I don't have a flutter/dart/android dev environment, so I can't actually test these changes, however.

Syntax is from https://flutteragency.com/configure-auto-capitalization-behavior-text-entry-fields/
