### PR TITLE
add badges for fdroid, GitHub release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A simple noiseless [Hacker News](https://news.ycombinator.com/) client made with
 
 [![App Store](https://img.shields.io/itunes/v/1602043763?label=App%20Store)](https://apps.apple.com/us/app/hacki/id1602043763?platform=iphone)
 [![Play Store](https://img.shields.io/badge/Play%20Store--yellow)](https://play.google.com/store/apps/details?id=com.jiaqifeng.hacki&hl=en_US&gl=US)
+[![Fdroid version](https://img.shields.io/f-droid/v/com.jiaqifeng.hacki)](https://f-droid.org/en/packages/com.jiaqifeng.hacki/)
+[![GH version](https://img.shields.io/github/release/livinglist/hacki.svg?logo=github)](https://github.com/Livinglist/Hacki/releases/latest)
 [![Visits Badge](https://badges.pufler.dev/visits/livinglist/Hacki)](https://badges.pufler.dev)
 [![GitHub](https://img.shields.io/github/stars/livinglist/Hacki?style=social)](https://img.shields.io/github/stars/livinglist/Hacki?style=social)
 [![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://pub.dev/packages/effective_dart)


### PR DESCRIPTION
The version release on the fdroid badge lags, though. Current version is 0.2.14 in fdroid repo, 0.2.11 (displayed in badge and on the fdroid website) was a week ago.

https://github.com/badges/shields/issues/5259 is discussion for fdroid's API, which lags as well. I'm not sure why this API isn't part of fdroid server itself; rather than having a separate program (that just be run manually!) parse the index and generate files, it should be trivial to generate a json file with version number for each apk after build, and include that directly in the repo instead of making it part of the static site. Sign the file and include other metadata, and fdroid client could also use this file to refresh a single package's metadata without waiting for the entire index (and all other repos) to download first (it's frustrating to know that fdroid has built a release, but have to wait several minutes for my slow network connection to download the repos, just so I can download a single file; worse yet, the client regularly crashes while updating if I continue to use it while updating repos).

Also, one should perhaps not be using githubusercontent links for images, I believe those may stop working eventually. Probably better to use links to images in the project's .github directory. It may also be worthwhile to remove the play store badge, since there's a larger link below and badges.io has no API for play store versions.