### PR TITLE
attempt to add a preference to use default browser

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,8 +5,12 @@
 
     <!-- Provide required visibility configuration for API level 30 and above -->
     <queries>
-        <intent>
+        <intent> <!-- https://developer.android.com/training/package-visibility/use-cases#open-urls-custom-tabs -->
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+        <intent> <!-- add3d category from same link. not sure if needed. -->
             <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
         </intent>
         <intent>

--- a/lib/cubits/preference/preference_cubit.dart
+++ b/lib/cubits/preference/preference_cubit.dart
@@ -21,6 +21,9 @@ class PreferenceCubit extends Cubit<PreferenceState> {
     _preferenceRepository.shouldShowComplexStoryTile.then(
       (bool value) => emit(state.copyWith(showComplexStoryTile: value)),
     );
+    _preferenceRepository.shouldUseInternalBrowser.then(
+      (bool value) => emit(state.copyWith(useInternalBrowser: value)),
+    );
     _preferenceRepository.shouldShowWebFirst
         .then((bool value) => emit(state.copyWith(showWebFirst: value)));
     _preferenceRepository.shouldShowEyeCandy
@@ -43,6 +46,11 @@ class PreferenceCubit extends Cubit<PreferenceState> {
   void toggleDisplayMode() {
     emit(state.copyWith(showComplexStoryTile: !state.showComplexStoryTile));
     _preferenceRepository.toggleDisplayMode();
+  }
+
+  void toggleBrowserMode() {
+    emit(state.copyWith(useInternalBrowser: !state.useInternalBrowser));
+    _preferenceRepository.toggleBrowserMode();
   }
 
   void toggleNavigationMode() {

--- a/lib/repositories/preference_repository.dart
+++ b/lib/repositories/preference_repository.dart
@@ -33,6 +33,10 @@ class PreferenceRepository {
   /// tile should display link preview. Defaults to true.
   static const String _displayModeKey = 'displayMode';
 
+  /// The key of a boolean value deciding whether or not the internal
+  /// webview browser should be used. Defaults to true.
+  static const String _browserModeKey = 'browserMode';
+
   /// The key of a boolean value deciding whether or not user should be
   /// navigated to web view first. Defaults to false.
   static const String _navigationModeKey = 'navigationMode';
@@ -41,6 +45,7 @@ class PreferenceRepository {
 
   static const bool _notificationModeDefaultValue = true;
   static const bool _displayModeDefaultValue = true;
+  static const bool _browserModeDefaultValue = true;
   static const bool _navigationModeDefaultValue = true;
   static const bool _eyeCandyModeDefaultValue = false;
   static const bool _trueDarkModeDefaultValue = false;
@@ -78,6 +83,11 @@ class PreferenceRepository {
   Future<bool> get shouldShowComplexStoryTile async => _prefs.then(
         (SharedPreferences prefs) =>
             prefs.getBool(_displayModeKey) ?? _displayModeDefaultValue,
+      );
+
+  Future<bool> get shouldUseInternalBrowser async => _prefs.then(
+        (SharedPreferences prefs) =>
+            prefs.getBool(_browserModeKey) ?? _browserModeDefaultValue,
       );
 
   Future<bool> get shouldShowWebFirst async => _prefs.then(
@@ -161,6 +171,13 @@ class PreferenceRepository {
     final bool currentMode =
         prefs.getBool(_displayModeKey) ?? _displayModeDefaultValue;
     await prefs.setBool(_displayModeKey, !currentMode);
+  }
+
+  Future<void> toggleBrowserMode() async {
+    final SharedPreferences prefs = await _prefs;
+    final bool currentMode =
+        prefs.getBool(_browserModeKey) ?? _browserModeDefaultValue;
+    await prefs.setBool(_browserModeKey, !currentMode);
   }
 
   Future<void> toggleNavigationMode() async {

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -295,6 +295,20 @@ class _ProfileScreenState extends State<ProfileScreen>
                                 activeColor: Colors.orange,
                               ),
                               SwitchListTile(
+                                title: const Text('Use WebView'),
+                                subtitle: const Text(
+                                  'open pages in webview or use default browser.',
+                                ),
+                                value: preferenceState.useInternalBrowser,
+                                onChanged: (bool val) {
+                                  HapticFeedback.lightImpact();
+                                  context
+                                      .read<PreferenceCubit>()
+                                      .toggleBrowserMode();
+                                },
+                                activeColor: Colors.orange,
+                              ),
+                              SwitchListTile(
                                 title: const Text('Show Metadata'),
                                 subtitle: const Text(
                                   'show number of comments and post date'

--- a/lib/utils/link_util.dart
+++ b/lib/utils/link_util.dart
@@ -19,7 +19,7 @@ abstract class LinkUtil {
     final Uri uri = rinseLink(link);
     canLaunchUrl(uri).then((bool val) {
       if (val) {
-        if (link.contains('http')) {
+        if (link.contains('http') && preferenceState.useInternalBrowser) {
           _browser
               .open(
                 url: uri,


### PR DESCRIPTION
not sure if this will work. i do not have a flutter/dart environment and have never done anything with it before. basically i just `fgrep -i complexstory . -R` and for  and duplicated them for a browser view
resources used:
- https://flutterforyou.com/how-to-open-url-in-external-browser-in-flutter/
- https://pub.dev/packages/url_launcher
- https://developer.android.com/training/package-visibility/use-cases#java

I have no idea what the chromesafaribrowserclass does, but an guessing it's related to enforcing WebView, so i left that section alone, apart from modifying the conditional. I'm hoping this does what i want (it probably wont), or is at least helpful. Basically, I'm hoping that the last `launchUrl()` starts the default browser; this is the part I'm unsure about (according to the resources above, it should. But then why didn't the `launchUrl()` above that do it?)

[Custom tabs](https://pub.dev/packages/flutter_custom_tabs) would be better, but, again, I don't really know what I'm doing here. It also doesn't help that I'm doing this on my tablet without an IDE (I'm using termux/nano). Partially I want to be able to use my ad blocker, partially I want to use reader mode, partially I want to be able to share URLs to other apps (I'll be submitting a request for this as well). Secondly, it would also be nice to have URLs registered with other apps open in them (e.g. redreader for Reddit, [untrackme](https://www.f-droid.org/en/packages/app.fedilab.nitterizeme/) for Twitter, YouTube, medium, etc.