### PR TITLE
Fix visibe comment after collapse

### DIFF
--- a/lib/models/preference.dart
+++ b/lib/models/preference.dart
@@ -164,7 +164,7 @@ final class AutoScrollModePreference extends BooleanPreference {
   const AutoScrollModePreference({bool? val})
       : super(val: val ?? _autoScrollModeDefaultValue);
 
-  static const bool _autoScrollModeDefaultValue = false;
+  static const bool _autoScrollModeDefaultValue = true;
 
   @override
   AutoScrollModePreference copyWith({required bool? val}) {

--- a/lib/screens/widgets/comment_tile.dart
+++ b/lib/screens/widgets/comment_tile.dart
@@ -420,12 +420,12 @@ class CommentTile extends StatelessWidget {
       final int indexOfNextComment = comments.indexOf(comment) + 1;
       if (indexOfNextComment < comments.length) {
         Future<void>.delayed(
-          AppDurations.ms300,
+          Duration.zero,
           () {
             commentsCubit.itemScrollController.scrollTo(
               index: indexOfNextComment,
               alignment: 0.1,
-              duration: AppDurations.ms300,
+              duration: AppDurations.ms100,
             );
           },
         );


### PR DESCRIPTION
This is the stupidest PR of my life. I was frustrated because collapsing comments sometimes required scrolling up. I dug into the codebase and realized that a fix for this already existed, but it was off by default. I imagine you don't have stats on how many people enable this feature or are frustrated because they don't know it exists, but if my experience is anything to go by enabling it by default and making the animation much quicker would improve the UX.