### PR TITLE
fix: corrupt collapse state

### DIFF
--- a/lib/cubits/comments/comments_cubit.dart
+++ b/lib/cubits/comments/comments_cubit.dart
@@ -328,14 +328,14 @@ class CommentsCubit extends Cubit<CommentsState> with Loggable {
       return;
     }
 
+    /// Preserve collapse state.
+    _preserveCollapseState();
+
     emit(
       state.copyWith(
         status: CommentsStatus.inProgress,
       ),
     );
-
-    /// Preserve collapse state.
-    _preserveCollapseState();
 
     final Item item = state.item;
     final Item updatedItem =


### PR DESCRIPTION
- node comments of uncollapsed comment are only looking at root comment for collapse state, instead, they should be look at their own parent.
- do not preserve collapse state when the comments are still loading. Otherwise previous state will be overwritten with corrupt one.