### PR TITLE
feat: dynamic colors

### DIFF
--- a/lib/cubits/preference/preference_state.dart
+++ b/lib/cubits/preference/preference_state.dart
@@ -103,6 +103,8 @@ class PreferenceState extends Equatable {
 
   bool get isDevModeEnabled => _isOn<DevMode>();
 
+  bool get isDynamicColorEnabled => _isOn<DynamicColorPreference>();
+
   bool get isHackerNewsThemeEnabled => _isOn<HackerNewsThemePreference>();
 
   bool get isPreviewImageLeftAligned =>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:equatable/equatable.dart';
 import 'package:feature_discovery/feature_discovery.dart';
 import 'package:flutter/foundation.dart';
@@ -232,6 +233,7 @@ class HackiApp extends StatelessWidget {
             previous.font != current.font ||
             previous.textScaleFactor != current.textScaleFactor ||
             previous.isTrueDarkModeEnabled != current.isTrueDarkModeEnabled ||
+            previous.isDynamicColorEnabled != current.isDynamicColorEnabled ||
             previous.isHackerNewsThemeEnabled !=
                 current.isHackerNewsThemeEnabled ||
             previous.isDevModeEnabled != current.isDevModeEnabled,
@@ -285,59 +287,81 @@ class HackiApp extends StatelessWidget {
                                       Brightness.dark);
                         }
                       }();
-                      final ColorScheme colorScheme = ColorScheme.fromSeed(
-                        brightness: isDarkModeEnabled
-                            ? Brightness.dark
-                            : Brightness.light,
-                        seedColor: state.appColor,
-                        dynamicSchemeVariant: DynamicSchemeVariant.fidelity,
-                      );
-                      return FeatureDiscovery(
-                        child: MediaQuery(
-                          data: state.textScaleFactor == 1
-                              ? MediaQuery.of(context)
-                              : MediaQuery.of(context).copyWith(
-                                  textScaler: TextScaler.linear(
-                                    state.textScaleFactor,
+                      return DynamicColorBuilder(
+                        builder:
+                            (
+                              ColorScheme? lightDynamic,
+                              ColorScheme? darkDynamic,
+                            ) {
+                              final ColorScheme fallbackColorScheme =
+                                  ColorScheme.fromSeed(
+                                    brightness: isDarkModeEnabled
+                                        ? Brightness.dark
+                                        : Brightness.light,
+                                    seedColor: state.appColor,
+                                    dynamicSchemeVariant:
+                                        DynamicSchemeVariant.fidelity,
+                                  );
+                              final ColorScheme colorScheme =
+                                  state.isDynamicColorEnabled
+                                  ? ((isDarkModeEnabled
+                                            ? darkDynamic
+                                            : lightDynamic) ??
+                                        fallbackColorScheme)
+                                  : fallbackColorScheme;
+                              return FeatureDiscovery(
+                                child: MediaQuery(
+                                  data: state.textScaleFactor == 1
+                                      ? MediaQuery.of(context)
+                                      : MediaQuery.of(context).copyWith(
+                                          textScaler: TextScaler.linear(
+                                            state.textScaleFactor,
+                                          ),
+                                        ),
+                                  child: MaterialApp.router(
+                                    title: 'Hacki',
+                                    debugShowCheckedModeBanner: false,
+                                    darkTheme: state.isHackerNewsThemeEnabled
+                                        ? HackerNewsDarkTheme.theme
+                                        : null,
+                                    theme: state.isHackerNewsThemeEnabled
+                                        ? HackerNewsTheme.theme
+                                        : AppTheme.theme(
+                                            colorScheme,
+                                            state.font,
+                                            isDarkModeEnabled:
+                                                isDarkModeEnabled,
+                                            isTrueDarkModeEnabled:
+                                                state.isTrueDarkModeEnabled,
+                                          ),
+                                    routerConfig: router,
+                                    builder: state.isDevModeEnabled
+                                        ? (
+                                            BuildContext context,
+                                            Widget? child,
+                                          ) => Stack(
+                                            children: <Widget>[
+                                              Positioned.fill(child: child!),
+                                              DraggableFloatingButton(
+                                                onTap: () {
+                                                  router.push(
+                                                    Paths.logs.landing,
+                                                  );
+                                                },
+                                                child: Icon(
+                                                  Icons.bug_report,
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onPrimaryContainer,
+                                                ),
+                                              ),
+                                            ],
+                                          )
+                                        : null,
                                   ),
                                 ),
-                          child: MaterialApp.router(
-                            title: 'Hacki',
-                            debugShowCheckedModeBanner: false,
-                            darkTheme: state.isHackerNewsThemeEnabled
-                                ? HackerNewsDarkTheme.theme
-                                : null,
-                            theme: state.isHackerNewsThemeEnabled
-                                ? HackerNewsTheme.theme
-                                : AppTheme.theme(
-                                    colorScheme,
-                                    state.font,
-                                    isDarkModeEnabled: isDarkModeEnabled,
-                                    isTrueDarkModeEnabled:
-                                        state.isTrueDarkModeEnabled,
-                                  ),
-                            routerConfig: router,
-                            builder: state.isDevModeEnabled
-                                ? (BuildContext context, Widget? child) =>
-                                      Stack(
-                                        children: <Widget>[
-                                          Positioned.fill(child: child!),
-                                          DraggableFloatingButton(
-                                            onTap: () {
-                                              router.push(Paths.logs.landing);
-                                            },
-                                            child: Icon(
-                                              Icons.bug_report,
-                                              color: Theme.of(
-                                                context,
-                                              ).colorScheme.onPrimaryContainer,
-                                            ),
-                                          ),
-                                        ],
-                                      )
-                                : null,
-                          ),
-                        ),
+                              );
+                            },
                       );
                     },
               );

--- a/lib/models/preference.dart
+++ b/lib/models/preference.dart
@@ -85,6 +85,7 @@ abstract final class Preference<T> extends Equatable with SettingsDisplayable {
         const WebViewBottomSheetPreference(),
         const DividerPlaceholder(label: 'Look And Feel'),
         const EyeCandyPreference(),
+        const DynamicColorPreference(),
         const HackerNewsThemePreference(),
         const HapticFeedbackPreference(),
         const TrueDarkModePreference(),
@@ -117,6 +118,35 @@ final class DividerPlaceholder extends Preference<void> {
 
 abstract final class BooleanPreference extends Preference<bool> {
   const BooleanPreference({required super.val});
+
+  String? dependencyErrorMessage(Iterable<Preference<dynamic>> preferences) {
+    final List<String> unmetDependencies = <String>[];
+
+    for (final Preference<dynamic> dependency in dependencies) {
+      final Preference<dynamic>? concreteDependency = preferences
+          .singleWhereOrNull(
+            (Preference<dynamic> pref) => pref.key == dependency.key,
+          );
+      if (concreteDependency?.val != dependency.val) {
+        final String action = dependency.val == true ? 'enable' : 'disable';
+        unmetDependencies.add('$action ${dependency.title}');
+      }
+    }
+
+    if (unmetDependencies.isEmpty) {
+      return null;
+    }
+
+    final String precedingDependencies = unmetDependencies
+        .sublist(0, unmetDependencies.length - 1)
+        .join(', ');
+    final String dependencyList = switch (unmetDependencies.length) {
+      1 => unmetDependencies.single,
+      2 => '${unmetDependencies.first} and ${unmetDependencies.last}',
+      _ => '$precedingDependencies, and ${unmetDependencies.last}',
+    };
+    return 'Please $dependencyList first.';
+  }
 }
 
 abstract final class IntPreference extends Preference<int> {
@@ -247,6 +277,11 @@ final class HackerNewsThemePreference extends BooleanPreference {
   HackerNewsThemePreference copyWith({required bool? val}) {
     return HackerNewsThemePreference(val: val);
   }
+
+  @override
+  Set<Preference<dynamic>> get dependencies => <Preference<dynamic>>{
+    const DynamicColorPreference(val: false),
+  };
 
   @override
   String get key => 'hackerNewsThemePreference';
@@ -793,6 +828,35 @@ final class TrueDarkModePreference extends BooleanPreference {
 
   @override
   String get subtitle => 'real dark.';
+}
+
+final class DynamicColorPreference extends BooleanPreference {
+  const DynamicColorPreference({bool? val})
+    : super(val: val ?? _dynamicColorPreferenceDefaultValue);
+
+  static const bool _dynamicColorPreferenceDefaultValue = false;
+
+  @override
+  DynamicColorPreference copyWith({required bool? val}) {
+    return DynamicColorPreference(val: val);
+  }
+
+  @override
+  Set<Preference<dynamic>> get dependencies => <Preference<dynamic>>{
+    const HackerNewsThemePreference(val: false),
+  };
+
+  @override
+  String get key => 'dynamicColor';
+
+  @override
+  String get title => 'Dynamic Colors';
+
+  @override
+  String get subtitle => 'wallpaper colors.';
+
+  @override
+  bool get isDisplayable => Platform.isAndroid;
 }
 
 final class HapticFeedbackPreference extends BooleanPreference {

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -298,17 +298,18 @@ class _SettingsViewState extends State<SettingsView>
                         selected: <bool>{
                           preferenceState.isOn(preference as BooleanPreference),
                         },
-                        onSelectionChanged:
-                            preference.dependencies.satisfy(
-                              preferenceState.preferences,
-                            )
-                            ? (Set<bool> val) {
-                                HapticFeedbackUtils.light();
-                                context.read<PreferenceCubit>().update(
-                                  preference.copyWith(val: val.single),
-                                );
-                              }
-                            : null,
+                        onSelectionChanged: (Set<bool> val) {
+                          HapticFeedbackUtils.light();
+                          if (!preference.dependencies.satisfy(
+                            preferenceState.preferences,
+                          )) {
+                            showDependencyError(preference);
+                            return;
+                          }
+                          context.read<PreferenceCubit>().update(
+                            preference.copyWith(val: val.single),
+                          );
+                        },
                       ),
                     ),
                   )
@@ -322,25 +323,26 @@ class _SettingsViewState extends State<SettingsView>
                     value: preferenceState.isOn(
                       preference as BooleanPreference,
                     ),
-                    onChanged:
-                        preference.dependencies.satisfy(
-                          preferenceState.preferences,
-                        )
-                        ? (bool val) {
-                            HapticFeedbackUtils.light();
+                    onChanged: (bool val) {
+                      HapticFeedbackUtils.light();
 
-                            context.read<PreferenceCubit>().update(
-                              preference.copyWith(val: val),
-                            );
+                      if (val &&
+                          !preference.dependencies.satisfy(
+                            preferenceState.preferences,
+                          )) {
+                        showDependencyError(preference);
+                        return;
+                      }
 
-                            if (preference is MarkReadStoriesModePreference &&
-                                val == false) {
-                              context.read<StoriesBloc>().add(
-                                ClearAllReadStories(),
-                              );
-                            }
-                          }
-                        : null,
+                      context.read<PreferenceCubit>().update(
+                        preference.copyWith(val: val),
+                      );
+
+                      if (preference is MarkReadStoriesModePreference &&
+                          val == false) {
+                        context.read<StoriesBloc>().add(ClearAllReadStories());
+                      }
+                    },
                     activeThumbColor: Theme.of(context).colorScheme.primary,
                   ),
                 if (preference is MarkReadStoriesModePreference) ...<Widget>[
@@ -519,10 +521,26 @@ class _SettingsViewState extends State<SettingsView>
     );
   }
 
+  void showDependencyError(Preference<dynamic> preference) {
+    if (preference is! BooleanPreference) {
+      return;
+    }
+    final String? message = preference.dependencyErrorMessage(
+      context.read<PreferenceCubit>().state.preferences,
+    );
+    if (message != null) {
+      context
+        ..removeSnackBar()
+        ..showErrorSnackBar(message);
+    }
+  }
+
   void showHackerNewsThemeError() {
-    context
-      ..removeSnackBar()
-      ..showErrorSnackBar('Please disable Hacker News Theme first.');
+    showDependencyError(const DynamicColorPreference(val: true));
+  }
+
+  void showDynamicColorError() {
+    showDependencyError(const HackerNewsThemePreference(val: true));
   }
 
   void showFontSettingDialog() {
@@ -621,8 +639,15 @@ class _SettingsViewState extends State<SettingsView>
   }
 
   void showColorPicker() {
-    if (context.read<PreferenceCubit>().state.isHackerNewsThemeEnabled) {
+    final PreferenceState preferenceState = context
+        .read<PreferenceCubit>()
+        .state;
+    if (preferenceState.isHackerNewsThemeEnabled) {
       showHackerNewsThemeError();
+      return;
+    }
+    if (preferenceState.isDynamicColorEnabled) {
+      showDynamicColorError();
       return;
     }
     showDialog<void>(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -321,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   equatable:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   connectivity_plus: ^7.3.1
   device_info_plus: ^13.1.0
   dio: ^5.11.0
+  dynamic_color: ^1.8.1
   dio_smart_retry: ^7.0.1
   equatable: ^2.1.0
   fast_gbk: ^1.0.0


### PR DESCRIPTION
## Revision 1 Changes
> 1. Adds Material You dynamic colors support and preference toggle.
> 2. Handles conflicts with Accent Color and HackerNews theme selection gracefully.
> 3. Limits platform to Android.
> 4. Adds generic support for conflict exceptions on dependencies.

## Why
> - 1.1: Improves consistency across applications when using dynamic colors system-wide.
> - 1.2: Prevents conflicts between other color selections while allowing for fonts, theme, and true black selections to remain.
> - 1.3: Material You is an Android exclusive feature.
> - 1.4: More scalable approach to adding new dependencies and displaying conflict errors to users.

## Testing
> - Built the debug `.apk` and tested dynamic colors as well as conflict resolution.
> - Tested on Android 17 with [Build Android APK workflow](https://github.com/eames-palmer/Hacki/actions/runs/30982908725/job/92231063627).
>
> - **Dynamic Colors attempting to click Hacker News Theme toggle (or Accent Colors):**
>
>    <img width="1280" height="2693" alt="Screenshot_20260805-225804" src="https://github.com/user-attachments/assets/2a2e2702-4aea-46e1-916f-316d1b4f46a7" />
> 
> - **Dynamic Colors with True Black:**
>
>    <img width="1280" height="2707" alt="Screenshot_20260805-230608" src="https://github.com/user-attachments/assets/6cf889c4-93bb-4c6b-b749-1b0882f195e7" />
>
> - **Hacker News Theme attempting to click Dynamic Colors toggle:**
>
>    <img width="1280" height="2710" alt="Screenshot_20260805-230518" src="https://github.com/user-attachments/assets/9312ddc8-2ca6-427f-9819-86bf2039c835" />





## Related Links
> - Addresses #531